### PR TITLE
Restricting python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.10.0',
+    python_requires='>=3.10, <3.12',
     packages=find_packages(),
     package_data={
         'avici': [


### PR DESCRIPTION
Hello gentlemen!
I have tried running this code, and I noticed that the building for pyarrow fails if the python version is above 3.11. I thus included that restriction in `setup.py` so that anyone who tries to install using `pip install .` won't have to search why it is not working.

I'd want to include a section akin to "Requirements" in the README to outline that restriction as to save time of other's, but I'll leave it up to you since I'm not sure of the best way of approaching it. I have also noticed the `environment.yaml` also includes a python version restriction, but I am not quite sure how it works.

I am not actually sure if python version 3.11 modifies how the code operates. I just checked that the installation passes and the example scripts run.